### PR TITLE
docs(storybook): fix styling order

### DIFF
--- a/docs/Getting-Started.stories.mdx
+++ b/docs/Getting-Started.stories.mdx
@@ -40,6 +40,7 @@ import ms_sans_serif from 'react95/dist/fonts/ms_sans_serif.woff2';
 import ms_sans_serif_bold from 'react95/dist/fonts/ms_sans_serif_bold.woff2';
 
 const GlobalStyles = createGlobalStyle`
+  ${styleReset}
   @font-face {
     font-family: 'ms_sans_serif';
     src: url('${ms_sans_serif}') format('woff2');
@@ -55,7 +56,6 @@ const GlobalStyles = createGlobalStyle`
   body, input, select, textarea {
     font-family: 'ms_sans_serif';
   }
-  ${styleReset}
 `;
 
 const App = () => (


### PR DESCRIPTION
On the Storybook docs, in the Getting Started page, the styleReset in its current position overrides the font-family rule defined in the previous lines. 

This commit simply changes the order of this line, so that the font-family rule does not get overridden.

This example now becomes coherent with this repo's README.md example as well. 