### PR TITLE
bug fix: "Active" button not getting focused state

### DIFF
--- a/src/Button/Button.tsx
+++ b/src/Button/Button.tsx
@@ -164,7 +164,7 @@ export const StyledButton = styled.button<StyledButtonProps>`
           }
           &:focus:after,
           &:active:after {
-            ${!active && !disabled && focusOutline}
+            ${!disabled && focusOutline}
             outline-offset: -8px;
           }
           &:active:focus:after,


### PR DESCRIPTION
The `focusOutline` was not including any case for active === true.

I've made changes in the file: `src\Button\Button.tsx`:
![image](https://user-images.githubusercontent.com/49808043/230751214-4c4bb5e6-7284-4563-aabc-6a9c24f7aec4.png)

Following is the working example of the fix for the 'Active' button, followed by a picture showing no other buttons' styles are being compromised:
![image](https://user-images.githubusercontent.com/49808043/230751259-83238241-9786-4669-b4f6-23327495f802.png)

![image](https://user-images.githubusercontent.com/49808043/230751296-63440370-85d7-429c-84b4-4c110eddb07b.png)

I hope this helps!

Fixes [#383](https://github.com/react95-io/React95/issues/383)

