### PR TITLE
feat(toolbar): add onOutsideClick prop

### DIFF
--- a/src/Toolbar/Toolbar.spec.tsx
+++ b/src/Toolbar/Toolbar.spec.tsx
@@ -26,4 +26,15 @@ describe('<Toolbar />', () => {
       expect(toolbar).toHaveStyleRule('padding', '0');
     });
   });
+
+  describe('prop: onOutsideClick', () => {
+    it('should fire callback on container click', () => {
+      const mockCallBack = jest.fn();
+      const { container } = render(<Toolbar onOutsideClick={mockCallBack} />);
+
+      container.click();
+
+      expect(mockCallBack).toHaveBeenCalled();
+    });
+  });
 });

--- a/src/Toolbar/Toolbar.tsx
+++ b/src/Toolbar/Toolbar.tsx
@@ -1,9 +1,11 @@
-import React, { forwardRef } from 'react';
+import React, { forwardRef, useRef, useEffect } from 'react';
 import styled from 'styled-components';
+import useForkRef from '../common/hooks/useForkRef';
 
 type ToolbarProps = {
   children?: React.ReactNode;
   noPadding?: boolean;
+  onOutsideClick?: () => void;
 } & React.HTMLAttributes<HTMLDivElement>;
 
 const StyledToolbar = styled.div<ToolbarProps>`
@@ -14,11 +16,34 @@ const StyledToolbar = styled.div<ToolbarProps>`
 `;
 
 const Toolbar = forwardRef<HTMLDivElement, ToolbarProps>(function Toolbar(
-  { children, noPadding = false, ...otherProps },
+  { children, noPadding = false, onOutsideClick, ...otherProps },
   ref
 ) {
+  const toolbarRef = useRef<HTMLDivElement | null>(null);
+  const handleRef = useForkRef(ref, toolbarRef);
+
+  useEffect(() => {
+    if (!onOutsideClick) {
+      return () => {};
+    }
+
+    const handleOutsideClick = (e: MouseEvent) => {
+      const target = e.target as Node;
+
+      if (!toolbarRef.current?.contains(target)) {
+        onOutsideClick();
+      }
+    };
+
+    document.addEventListener('click', handleOutsideClick);
+
+    return () => {
+      document.removeEventListener('click', handleOutsideClick);
+    };
+  }, [ref, onOutsideClick]);
+
   return (
-    <StyledToolbar noPadding={noPadding} ref={ref} {...otherProps}>
+    <StyledToolbar noPadding={noPadding} ref={handleRef} {...otherProps}>
       {children}
     </StyledToolbar>
   );


### PR DESCRIPTION
## Overview

This PR adds an optional `onOutsideClick` callback prop to the `Toolbar` component.

From a UX perspective, "toolbars" should close by default on an outside click. [Similar to how dropdowns are handled](https://github.com/react95-io/React95/blob/master/src/Select/useSelectState.ts#L540). Since the component itself does not handle visibility, we can add a prop for the consumer to make it easier to implement this behavior.

e.g
```tsx
<Toolbar onOutsideClick={() => setOpen(false)}>
  ...
</Toolbar>
```

![Kapture 2024-01-14 at 13 34 01](https://github.com/react95-io/React95/assets/16131737/da9be16a-26a3-4c2a-9a06-eaf4ee124cf1)

![Kapture 2024-01-14 at 13 43 26](https://github.com/react95-io/React95/assets/16131737/0a7fbc92-b716-4b86-95b6-0ab54c6feada)


- [x] Tested locally
- [x] Added tests
- [x] Backwards compatible (opt-in)


Thank you for the awesome library!
