### PR TITLE
fix("Slider"): update hook to prevent crash in Next.js 15 / React 19

### DIFF
--- a/src/common/hooks/useIsFocusVisible.ts
+++ b/src/common/hooks/useIsFocusVisible.ts
@@ -2,7 +2,6 @@
 // based on https://github.com/WICG/focus-visible/blob/v4.1.5/src/focus-visible.js
 
 import { useCallback } from 'react';
-import { findDOMNode } from 'react-dom';
 
 let hadKeyboardEvent = true;
 let hadFocusVisibleRecently = false;
@@ -138,9 +137,7 @@ function handleBlurVisible() {
 }
 
 export function useIsFocusVisible<T extends Element = HTMLElement>() {
-  const ref = useCallback((instance: T) => {
-    // eslint-disable-next-line react/no-find-dom-node
-    const node = findDOMNode(instance);
+  const ref = useCallback((node: T) => {
     if (node != null) {
       prepare(node.ownerDocument);
     }


### PR DESCRIPTION
React 19 RC removes findDOMNode making the Slider crash Next.js 15 / React 19 apps.

BREAKING CHANGE
This may be a breaking change for React 16 and/or earlier versions.