### PR TITLE
Remove findDOMNode

### DIFF
--- a/src/common/hooks/useIsFocusVisible.ts
+++ b/src/common/hooks/useIsFocusVisible.ts
@@ -2,7 +2,6 @@
 // based on https://github.com/WICG/focus-visible/blob/v4.1.5/src/focus-visible.js
 
 import { useCallback } from 'react';
-import { findDOMNode } from 'react-dom';
 
 let hadKeyboardEvent = true;
 let hadFocusVisibleRecently = false;
@@ -140,7 +139,7 @@ function handleBlurVisible() {
 export function useIsFocusVisible<T extends Element = HTMLElement>() {
   const ref = useCallback((instance: T) => {
     // eslint-disable-next-line react/no-find-dom-node
-    const node = findDOMNode(instance);
+    const node = instance;
     if (node != null) {
       prepare(node.ownerDocument);
     }


### PR DESCRIPTION
## Remove `findDOMNode` (React 19 compatibility)

`ReactDOM.findDOMNode` was removed in React 19. The `useIsFocusVisible` hook
was calling it to resolve the DOM node from a ref callback, which breaks
entirely in React 19.

The fix is straightforward — ref callbacks already receive the DOM node as
`instance`, so `findDOMNode` was never doing anything useful here. Dropping
it and using `instance` directly is equivalent behavior.

Fixes the following crash when running React 19:
`TypeError: reactDom.findDOMNode is not a function`